### PR TITLE
Add the possibility to parse number in scientific notation with E

### DIFF
--- a/strnum.js
+++ b/strnum.js
@@ -1,5 +1,5 @@
 const hexRegex = /0x[a-zA-Z0-9]+/;
-const numRegex = /^([\-\+])?(0*)(\.[0-9]+(e\-?[0-9]+)?|[0-9]+(\.[0-9]+(e\-?[0-9]+)?)?)$/;
+const numRegex = /^([\-\+])?(0*)(\.[0-9]+([eE]\-?[0-9]+)?|[0-9]+(\.[0-9]+([eE]\-?[0-9]+)?)?)$/;
 // const octRegex = /0x[a-z0-9]+/;
 // const binRegex = /0x[a-z0-9]+/;
 
@@ -20,9 +20,9 @@ function toNumber(str, options = {}){
 
     options = Object.assign({}, consider, options );
     if(!str || typeof str !== "string" ) return str;
-    
+
     let trimmedStr  = str.trim();
-    
+
     if(options.skipLike !== undefined && options.skipLike.test(trimmedStr)) return str;
     else if (options.hex && hexRegex.test(trimmedStr)) {
         return Number.parseInt(trimmedStr, 16);

--- a/strnum.test.js
+++ b/strnum.test.js
@@ -43,7 +43,7 @@ describe("Should convert all the valid numeric strings to number", () => {
         expect(toNumber(".006")).toEqual(0.006);
         expect(toNumber("6.0")).toEqual(6);
         expect(toNumber("06.0")).toEqual(6);
-        
+
         expect(toNumber("0.0",  { leadingZeros :  false})).toEqual(0);
         expect(toNumber("00.00",  { leadingZeros :  false})).toEqual("00.00");
         expect(toNumber("0.06",  { leadingZeros :  false})).toEqual(0.06);
@@ -56,7 +56,7 @@ describe("Should convert all the valid numeric strings to number", () => {
         expect(toNumber("-06")).toEqual(-6);
         expect(toNumber("-06", { leadingZeros :  true})).toEqual(-6);
         expect(toNumber("-06", { leadingZeros :  false})).toEqual("-06");
-        
+
         expect(toNumber("-0.0")).toEqual(-0);
         expect(toNumber("-00.00")).toEqual(-0);
         expect(toNumber("-0.06")).toEqual(-0.06);
@@ -64,7 +64,7 @@ describe("Should convert all the valid numeric strings to number", () => {
         expect(toNumber("-.006")).toEqual(-0.006);
         expect(toNumber("-6.0")).toEqual(-6);
         expect(toNumber("-06.0")).toEqual(-6);
-        
+
         expect(toNumber("-0.0"   ,  { leadingZeros :  false})).toEqual(-0);
         expect(toNumber("-00.00",  { leadingZeros :  false})).toEqual("-00.00");
         expect(toNumber("-0.06",  { leadingZeros :  false})).toEqual(-0.06);
@@ -87,6 +87,17 @@ describe("Should convert all the valid numeric strings to number", () => {
 
         expect(toNumber("-1.0e2") ).toEqual(-100);
         expect(toNumber("1.0e-2")).toEqual(0.01);
+    });
+
+    it("scientific notation with upper E", () => {
+        expect(toNumber("01.0E2"  ,  { leadingZeros :  false})).toEqual("01.0E2");
+        expect(toNumber("-01.0E2"  ,  { leadingZeros :  false})).toEqual("-01.0E2");
+        expect(toNumber("01.0E2") ).toEqual(100);
+        expect(toNumber("-01.0E2") ).toEqual(-100);
+        expect(toNumber("1.0E2") ).toEqual(100);
+
+        expect(toNumber("-1.0E2") ).toEqual(-100);
+        expect(toNumber("1.0E-2")).toEqual(0.01);
     });
 
     it("should skip matching pattern", () => {


### PR DESCRIPTION
As mention in #1 , we don't have the possibility to parse scientific notation with upper E. So this PR add this specificity.