### PR TITLE
Fix the hex regex

### DIFF
--- a/strnum.js
+++ b/strnum.js
@@ -1,4 +1,4 @@
-const hexRegex = /^0x[a-fA-F0-9]+$/;
+const hexRegex = /^[-+]?0x[a-fA-F0-9]+$/;
 const numRegex = /^([\-\+])?(0*)(\.[0-9]+(e\-?[0-9]+)?|[0-9]+(\.[0-9]+(e\-?[0-9]+)?)?)$/;
 // const octRegex = /0x[a-z0-9]+/;
 // const binRegex = /0x[a-z0-9]+/;

--- a/strnum.js
+++ b/strnum.js
@@ -1,4 +1,4 @@
-const hexRegex = /0x[a-zA-Z0-9]+/;
+const hexRegex = /^0x[a-fA-F0-9]+$/;
 const numRegex = /^([\-\+])?(0*)(\.[0-9]+(e\-?[0-9]+)?|[0-9]+(\.[0-9]+(e\-?[0-9]+)?)?)$/;
 // const octRegex = /0x[a-z0-9]+/;
 // const binRegex = /0x[a-z0-9]+/;

--- a/strnum.test.js
+++ b/strnum.test.js
@@ -18,13 +18,19 @@ describe("Should convert all the valid numeric strings to number", () => {
         expect(toNumber("12+12")).toEqual("12+12");
         expect(toNumber("1212+")).toEqual("1212+");
     })
-    it("should parse hexaDecimal values", () => {
+    it("should parse hexadecimal values", () => {
         expect(toNumber("0x2f")).toEqual(47);
         expect(toNumber("-0x2f")).toEqual(-47);
         expect(toNumber("0x2f", { hex :  true})).toEqual(47);
         expect(toNumber("-0x2f", { hex :  true})).toEqual(-47);
         expect(toNumber("0x2f", { hex :  false})).toEqual("0x2f");
         expect(toNumber("-0x2f", { hex :  false})).toEqual("-0x2f");
+    })
+    it("should not parse strings with 0x embedded", () => {
+        expect(toNumber("0xzz")).toEqual("0xzz");
+        expect(toNumber("iweraf0x123qwerqwer")).toEqual("iweraf0x123qwerqwer");
+        expect(toNumber("1230x55")).toEqual("1230x55");
+        expect(toNumber("JVBERi0xLjMNCiXi48")).toEqual("JVBERi0xLjMNCiXi48");
     })
     it("leading zeros", () => {
         expect(toNumber("06")).toEqual(6);
@@ -103,5 +109,4 @@ describe("Should convert all the valid numeric strings to number", () => {
     it("should ignore sorrounded spaces ", () => {
         expect(toNumber("   +1212   ")).toEqual(1212);
     })
-
 });


### PR DESCRIPTION
Fixes https://github.com/NaturalIntelligence/strnum/issues/4

* Updates the hex regex
  - Changes `a-z` and `A-Z` to use `a-f` and `A-F`
  - Adds `^` and `$` to force the regex to consider the whole string
  - Adds an optional `-` or `+` in front of the hex string
* Adds unit tests to verify